### PR TITLE
3.25-153

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,12 +19,12 @@ entVersion = v149.0.0
 mindustryBE = false
 # Mindustry *release* version, e.g. `v145` or `v146`.
 # Leave empty if `mindustryBE = true`.
-mindustryVersion = v149
+mindustryVersion = v153
 # Mindustry *bleeding-edge* version, corresponds to commit hashes of Anuken/MindustryJitpack, e.g. `345ea0d54de0aee6953a664468556f4fea1a7c4f`.
 # Leave empty if `mindustryBE = false`.
 mindustryBEVersion =
 # Arc version, should either follow `mindustryVersion` for release or whatever hash bleeding-edge Mindustry uses.
-arcVersion = v149
+arcVersion = v153
 
 ##### Android SDK configuration for building Android artifacts.
 # Android platform SDK version.

--- a/mod.hjson
+++ b/mod.hjson
@@ -2,7 +2,7 @@
     "displayName": "Extra Sand in the Sandbox - Redux",
     "subtitle": "It returns",
     "description": "A plethora of sandbox-only blocks dedicated for both fun and testing purposes.\n\n[red]REQUIRES `MEEPofFaith/black-hole-renderer` TO RUN. THE GAME WILL CRASH WITHOUT IT INSTALLED.[]",
-    "version": 3.2,
+    "version": 3.25,
     "minGameVersion": 153,
     "author": "MEEP of Faith",
     "java": true,

--- a/mod.hjson
+++ b/mod.hjson
@@ -3,7 +3,7 @@
     "subtitle": "It returns",
     "description": "A plethora of sandbox-only blocks dedicated for both fun and testing purposes.\n\n[red]REQUIRES `MEEPofFaith/black-hole-renderer` TO RUN. THE GAME WILL CRASH WITHOUT IT INSTALLED.[]",
     "version": 3.2,
-    "minGameVersion": 149,
+    "minGameVersion": 153,
     "author": "MEEP of Faith",
     "java": true,
     "main": "extrasandredux.ExtraSandRedux",


### PR DESCRIPTION
update those because target dummy crashes the game when it receives a status effect (and the same probably applies to flarogus too)

oh and you should probably make a 3.25 release because, well, version